### PR TITLE
Bump version to 4.14.1 and adjust select_quality

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.0"
+version_number="4.14.1"
 
 # UI
 
@@ -194,8 +194,9 @@ generate_link() {
 
 select_quality() {
     # removing urls which have soft subs to avoid playing on android, iSH and vlc (m3u8 streams don't get correct referrer)
-    printf '%s' "$player_function" | cut -f1 -d" " | grep -qE '(android|iSH|vlc)' && links=$(printf '%s' "$links" | sed '/cc>/d;/subtitle >/d;/m3u8_refr >/d')
-    printf '%s' "$player_function" | cut -f1 -d" " | grep -qE '(android|iSH)' && links=$(printf '%s' "$links" | sed '/Yt >/d')
+    # THE BELOW 2 LINES ARE COMMENTED OUT AS THE LATEST PROVIDER/SOURCES ARE BREAKING THE SCRIPT ON ANDROID DUE TO THESE; 
+    # printf '%s' "$player_function" | cut -f1 -d" " | grep -qE '(android|iSH|vlc)' && links=$(printf '%s' "$links" | sed '/cc>/d;/subtitle >/d;/m3u8_refr >/d')
+    # printf '%s' "$player_function" | cut -f1 -d" " | grep -qE '(android|iSH)' && links=$(printf '%s' "$links" | sed '/Yt >/d')
     case "$1" in
         best) result=$(printf "%s" "$links" | head -n1) ;;
         worst) result=$(printf "%s" "$links" | grep -E '^[0-9]{3,4}' | tail -n1) ;;
@@ -402,6 +403,7 @@ play_episode() {
                 [ "$exit_after_play" = 1 ] && [ -z "$range" ] && exit "$mpv_exitcode"
             fi
             ;;
+# SINCE REFERRER IS REQUIRED TO STREAM AND mpv-android DOESN'T ACCEPT REFERRER FLAGS THE SAME WAY ITS DESKTOP EQUIVALENT DOES, AN EDIT IN mpv.conf FILE IS MANUALLY REQUIRED
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         *iina*)


### PR DESCRIPTION
Updated version number to 4.14.1 and commented out lines in select_quality function to prevent script breaking on Android.

# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description
This is a temporary fix for the player issues in Termux. (like #pystardust/ani-cli/issues/1679 ). The soft subs removal code for android players returned no URLs to the player. So commenting it out returned the correct URLs. Also this fix only works for mpv. The vlc (-v flag) still doesn't work. Furthermore users are required to edit the `mpv.conf`  file by Opening `mpv > Settings > Advanced > Edit mpv.conf` for this fix to work
Then, in the text field that opens up, add the following line:
```
referrer=https://allmanga.to
```
## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [x] `-q` quality works
- [ ] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
